### PR TITLE
Fix panic in some cases in `push_metrics`

### DIFF
--- a/src/core/backend/pearl/settings.rs
+++ b/src/core/backend/pearl/settings.rs
@@ -81,7 +81,7 @@ impl Settings {
                                 disk_name,
                                 entry.path(),
                                 node_name.clone(),
-                                Arc::new(Semaphore::new(1))
+                                Arc::new(Semaphore::new(1)),
                             );
                             result.push(group);
                         } else {
@@ -118,7 +118,7 @@ impl Settings {
             disk_name,
             path,
             node_name.to_owned(),
-            Arc::new(Semaphore::new(1))
+            Arc::new(Semaphore::new(1)),
         );
         Ok(group)
     }

--- a/src/core/metrics/exporter/mod.rs
+++ b/src/core/metrics/exporter/mod.rs
@@ -1,6 +1,6 @@
 use super::prelude::IOError;
 use metrics::{Key, Recorder, SetRecorderError};
-use std::cell::RefCell;
+use std::sync::Mutex;
 use std::time::Duration;
 use tokio::sync::mpsc::{channel, Sender};
 
@@ -10,7 +10,7 @@ use send::send_metrics;
 
 const DEFAULT_ADDRESS: &str = "localhost:2003";
 const DEFAULT_DURATION: Duration = Duration::from_secs(1);
-const BUFFER_SIZE: usize = 1024;
+const BUFFER_SIZE: usize = 1_048_576; // 1 Mb
 
 #[derive(Debug)]
 pub(crate) enum Error {
@@ -57,7 +57,7 @@ impl MetricInner {
 }
 
 pub(crate) struct GraphiteRecorder {
-    tx: RefCell<Sender<Metric>>,
+    tx: Mutex<Sender<Metric>>,
 }
 
 pub(crate) struct GraphiteBuilder {
@@ -90,9 +90,7 @@ impl GraphiteBuilder {
 
     pub(crate) fn build(self) -> GraphiteRecorder {
         let (tx, rx) = channel(BUFFER_SIZE);
-        let recorder = GraphiteRecorder {
-            tx: RefCell::new(tx),
-        };
+        let recorder = GraphiteRecorder { tx: Mutex::new(tx) };
         tokio::spawn(send_metrics(rx, self.address, self.interval));
         recorder
     }
@@ -100,7 +98,8 @@ impl GraphiteBuilder {
 
 impl GraphiteRecorder {
     fn push_metric(&self, m: Metric) {
-        if let Err(e) = self.tx.borrow_mut().try_send(m) {
+        // mutex return Err only if another thread panicked while holding mutex
+        if let Err(e) = self.tx.lock().expect("Mutex unavailable").try_send(m) {
             error!(
                 "Can't send metric to thread, which processing metrics: {}",
                 e


### PR DESCRIPTION
#### Change refcell on mutex for interior mutability pattern implementation

`metrics` crate uses unsafe code and they cast Boxed_recorder to raw_recorder which violates some of Rust guarantees. I used RefCell data structure according to these guarantees (this data structure doesn't implement `Sync` trait, which guarantees that variables with this type won't be used in different threads), BUT unsafe code from used crate didn't allow compiler to notice this mistake and there was a case, when RefCell was borrowed by 2+ threads (and it's panic in this case). So using Mutex solves this problem (no need to use RWLock, cause `try_send` method of async channel always need mutable variable)