### PR TITLE
Fix metrics prefix

### DIFF
--- a/src/bin/docker_cluster_runner/mod.rs
+++ b/src/bin/docker_cluster_runner/mod.rs
@@ -203,10 +203,7 @@ impl TestClusterConfiguration {
             "quorum".to_string(),
             "pearl".to_string(),
             Some(self.get_pearl_config(node_index)),
-            Some(MetricsConfig::new(
-                "bob".to_string(),
-                "127.0.0.1:2003".to_string(),
-            )),
+            Some(MetricsConfig::new(None, "127.0.0.1:2003".to_string(), None)),
             RefCell::default(),
             RefCell::default(),
             self.cleanup_interval.clone(),

--- a/src/core/configs/mod.rs
+++ b/src/core/configs/mod.rs
@@ -7,7 +7,9 @@ mod reader;
 
 pub use self::cluster::{Cluster, Node as ClusterNode, Replica, VDisk};
 pub(crate) use self::node::BackendType;
-pub use self::node::{BackendSettings, MetricsConfig, Node, Pearl};
+pub use self::node::{
+    BackendSettings, MetricsConfig, Node, Pearl, LOCAL_ADDRESS, METRICS_NAME, NODE_NAME,
+};
 use super::prelude::*;
 
 mod prelude {

--- a/src/core/configs/node.rs
+++ b/src/core/configs/node.rs
@@ -100,17 +100,22 @@ impl BackendSettings {
 /// Contains params for graphite metrics.
 #[derive(Debug, PartialEq, Serialize, Deserialize, Clone, new)]
 pub struct MetricsConfig {
-    name: String,
+    name: Option<String>,
     graphite: String,
 }
 
 impl MetricsConfig {
+    pub(crate) fn name(&self) -> Option<&str> {
+        self.name.as_deref()
+    }
+
     pub(crate) fn graphite(&self) -> &str {
         &self.graphite
     }
 
     fn check_unset(&self) -> Result<(), String> {
-        if self.name == PLACEHOLDER || self.graphite == PLACEHOLDER {
+        if self.name.as_deref().map_or(false, |s| s == PLACEHOLDER) || self.graphite == PLACEHOLDER
+        {
             let msg = "some of the fields present, but empty".to_string();
             error!("{}", msg);
             Err(msg)
@@ -123,7 +128,7 @@ impl MetricsConfig {
 impl Validatable for MetricsConfig {
     fn validate(&self) -> Result<(), String> {
         self.check_unset()?;
-        if self.name.is_empty() {
+        if self.name.as_deref().map_or(false, str::is_empty) {
             debug!("field 'name' for 'metrics config' is empty");
             return Err("field 'name' for 'metrics config' is empty".to_string());
         }

--- a/src/core/configs/node.rs
+++ b/src/core/configs/node.rs
@@ -2,6 +2,12 @@ use super::prelude::*;
 
 const PLACEHOLDER: &str = "~";
 
+pub const LOCAL_ADDRESS: &str = "{local_address}";
+pub const NODE_NAME: &str = "{node_name}";
+pub const METRICS_NAME: &str = "{metrics_name}";
+
+const FIELD_PLACEHOLDER: &str = "_";
+
 /// Contains settings for pearl backend.
 #[derive(Debug, PartialEq, Serialize, Deserialize, Clone, new)]
 pub struct BackendSettings {
@@ -102,9 +108,14 @@ impl BackendSettings {
 pub struct MetricsConfig {
     name: Option<String>,
     graphite: String,
+    prefix: Option<String>,
 }
 
 impl MetricsConfig {
+    pub(crate) fn prefix(&self) -> Option<&str> {
+        self.prefix.as_deref()
+    }
+
     pub(crate) fn name(&self) -> Option<&str> {
         self.name.as_deref()
     }
@@ -114,8 +125,7 @@ impl MetricsConfig {
     }
 
     fn check_unset(&self) -> Result<(), String> {
-        if self.name.as_deref().map_or(false, |s| s == PLACEHOLDER) || self.graphite == PLACEHOLDER
-        {
+        if self.graphite == PLACEHOLDER {
             let msg = "some of the fields present, but empty".to_string();
             error!("{}", msg);
             Err(msg)
@@ -123,16 +133,22 @@ impl MetricsConfig {
             Ok(())
         }
     }
-}
 
-impl Validatable for MetricsConfig {
-    fn validate(&self) -> Result<(), String> {
-        self.check_unset()?;
-        if self.name.as_deref().map_or(false, str::is_empty) {
-            debug!("field 'name' for 'metrics config' is empty");
-            return Err("field 'name' for 'metrics config' is empty".to_string());
+    fn check_optional_fields(&self) -> Result<(), String> {
+        // Case, when field is set like `field: ''`
+        let optional_fields = [self.name.as_deref(), self.prefix.as_deref()];
+        if optional_fields
+            .iter()
+            .any(|field| field.map_or(false, str::is_empty))
+        {
+            debug!("one of optional fields for 'metrics config' is empty");
+            Err("one of optional fields for 'metrics config' is empty".to_string())
+        } else {
+            Ok(())
         }
+    }
 
+    fn check_graphite_addr(&self) -> Result<(), String> {
         if let Err(e) = self.graphite.parse::<SocketAddr>() {
             let msg = format!("field 'graphite': {} for 'metrics config' is invalid", e);
             error!("{}", msg);
@@ -140,6 +156,44 @@ impl Validatable for MetricsConfig {
         } else {
             Ok(())
         }
+    }
+
+    fn check_graphite_prefix(prefix: &str) -> Result<(), String> {
+        let invalid_char_predicate =
+            |c| !((c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z') || ("._".contains(c)));
+        if prefix.starts_with('.')
+            || prefix.ends_with('.')
+            || prefix.contains("..")
+            // check if there is '{', '}' or other invalid chars left
+            || prefix.find(invalid_char_predicate).is_some()
+        {
+            let msg = "Graphite 'prefix' is invalid".to_string();
+            error!("{}", msg);
+            Err(msg)
+        } else {
+            Ok(())
+        }
+    }
+
+    fn check_prefix(&self) -> Result<(), String> {
+        self.prefix.as_ref().cloned().map_or(Ok(()), |pref| {
+            let mut prefix = [LOCAL_ADDRESS, NODE_NAME]
+                .iter()
+                .fold(pref, |acc, field| acc.replace(field, FIELD_PLACEHOLDER));
+            if self.name.is_some() {
+                prefix = prefix.replace(METRICS_NAME, FIELD_PLACEHOLDER);
+            }
+            Self::check_graphite_prefix(&prefix)
+        })
+    }
+}
+
+impl Validatable for MetricsConfig {
+    fn validate(&self) -> Result<(), String> {
+        self.check_unset()?;
+        self.check_optional_fields()?;
+        self.check_graphite_addr()?;
+        self.check_prefix()
     }
 }
 

--- a/src/core/metrics/exporter/mod.rs
+++ b/src/core/metrics/exporter/mod.rs
@@ -7,7 +7,7 @@ mod retry_socket;
 mod send;
 use send::send_metrics;
 
-const DEFAULT_ADDRESS: &str = "localhost:2003";
+const DEFAULT_ADDRESS: &str = "127.0.0.1:2003";
 const DEFAULT_PREFIX: &str = "node.127_0_0_1";
 const DEFAULT_DURATION: Duration = Duration::from_secs(1);
 const BUFFER_SIZE: usize = 1_048_576; // 1 Mb

--- a/src/core/metrics/exporter/mod.rs
+++ b/src/core/metrics/exporter/mod.rs
@@ -8,6 +8,7 @@ mod send;
 use send::send_metrics;
 
 const DEFAULT_ADDRESS: &str = "localhost:2003";
+const DEFAULT_PREFIX: &str = "node.127_0_0_1";
 const DEFAULT_DURATION: Duration = Duration::from_secs(1);
 const BUFFER_SIZE: usize = 1_048_576; // 1 Mb
 
@@ -62,18 +63,25 @@ pub(crate) struct GraphiteRecorder {
 pub(crate) struct GraphiteBuilder {
     address: String,
     interval: Duration,
+    prefix: String,
 }
 
 impl GraphiteBuilder {
     pub(crate) fn new() -> GraphiteBuilder {
         GraphiteBuilder {
-            address: DEFAULT_ADDRESS.to_string(),
+            address: DEFAULT_ADDRESS.to_owned(),
             interval: DEFAULT_DURATION,
+            prefix: DEFAULT_PREFIX.to_owned(),
         }
     }
 
     pub(crate) fn set_interval(mut self, interval: Duration) -> GraphiteBuilder {
         self.interval = interval;
+        self
+    }
+
+    pub(crate) fn set_prefix(mut self, prefix: String) -> GraphiteBuilder {
+        self.prefix = prefix;
         self
     }
 
@@ -90,7 +98,7 @@ impl GraphiteBuilder {
     pub(crate) fn build(self) -> GraphiteRecorder {
         let (tx, rx) = channel(BUFFER_SIZE);
         let recorder = GraphiteRecorder { tx };
-        tokio::spawn(send_metrics(rx, self.address, self.interval));
+        tokio::spawn(send_metrics(rx, self.address, self.interval, self.prefix));
         recorder
     }
 }

--- a/src/core/metrics/exporter/send.rs
+++ b/src/core/metrics/exporter/send.rs
@@ -16,6 +16,7 @@ pub(super) async fn send_metrics(
     mut rx: Receiver<Metric>,
     address: String,
     send_interval: Duration,
+    prefix: String,
 ) {
     let mut socket =
         RetrySocket::new(address.parse().expect("Can't read address from String")).await;
@@ -37,9 +38,9 @@ pub(super) async fn send_metrics(
         }
 
         if let Ok(_) = socket.check_connection() {
-            flush_counters(&counters_map, &mut socket).await;
-            flush_gauges(&gauges_map, &mut socket).await;
-            flush_times(&mut times_map, &mut socket).await;
+            flush_counters(&counters_map, &mut socket, &prefix).await;
+            flush_gauges(&gauges_map, &mut socket, &prefix).await;
+            flush_times(&mut times_map, &mut socket, &prefix).await;
             if let Err(e) = socket.flush().await {
                 debug!("Socket flush error: {}", e);
             }
@@ -108,9 +109,13 @@ fn process_time(times_map: &mut HashMap<MetricKey, TimeEntry>, time: MetricInner
     entry.timestamp = time.timestamp;
 }
 
-async fn flush_counters(counters_map: &HashMap<MetricKey, CounterEntry>, socket: &mut RetrySocket) {
+async fn flush_counters(
+    counters_map: &HashMap<MetricKey, CounterEntry>,
+    socket: &mut RetrySocket,
+    prefix: &str,
+) {
     for (key, entry) in counters_map.iter() {
-        let data = format!("{} {} {}\n", key, entry.sum, entry.timestamp);
+        let data = format!("{}.{} {} {}\n", prefix, key, entry.sum, entry.timestamp);
         trace!(
             "Counter data: {:<30} {:<20} {:<20}",
             key,
@@ -123,9 +128,13 @@ async fn flush_counters(counters_map: &HashMap<MetricKey, CounterEntry>, socket:
     }
 }
 
-async fn flush_gauges(gauges_map: &HashMap<MetricKey, GaugeEntry>, socket: &mut RetrySocket) {
+async fn flush_gauges(
+    gauges_map: &HashMap<MetricKey, GaugeEntry>,
+    socket: &mut RetrySocket,
+    prefix: &str,
+) {
     for (key, entry) in gauges_map.iter() {
-        let data = format!("{} {} {}\n", key, entry.value, entry.timestamp);
+        let data = format!("{}.{} {} {}\n", prefix, key, entry.value, entry.timestamp);
         trace!(
             "Gauge   data: {:<30} {:<20} {:<20}",
             key,
@@ -138,13 +147,17 @@ async fn flush_gauges(gauges_map: &HashMap<MetricKey, GaugeEntry>, socket: &mut 
     }
 }
 
-async fn flush_times(times_map: &mut HashMap<MetricKey, TimeEntry>, socket: &mut RetrySocket) {
+async fn flush_times(
+    times_map: &mut HashMap<MetricKey, TimeEntry>,
+    socket: &mut RetrySocket,
+    prefix: &str,
+) {
     for (key, entry) in times_map.iter_mut() {
         let mean_time = match entry.measurements_amount {
             0 => entry.mean.expect("No mean time provided"),
             val => entry.summary_time / val,
         };
-        let data = format!("{} {} {}\n", key, mean_time, entry.timestamp);
+        let data = format!("{}.{} {} {}\n", prefix, key, mean_time, entry.timestamp);
         trace!(
             "Time    data: {:<30} {:<20} {:<20}",
             key,

--- a/src/core/mod.rs
+++ b/src/core/mod.rs
@@ -42,7 +42,9 @@ mod prelude {
     pub(crate) use bob_client::{BobClient, Factory};
     pub(crate) use cleaner::Cleaner;
     pub(crate) use cluster::{get_cluster, Cluster};
-    pub(crate) use configs::{Cluster as ClusterConfig, Node as NodeConfig};
+    pub(crate) use configs::{
+        Cluster as ClusterConfig, Node as NodeConfig, LOCAL_ADDRESS, METRICS_NAME, NODE_NAME,
+    };
     pub(crate) use counter::Counter as BlobsCounter;
     pub(crate) use data::{BobData, BobFlags, BobKey, BobMeta, BobOptions, DiskPath, VDiskID};
     pub(crate) use futures::{

--- a/test_env/node1.yaml
+++ b/test_env/node1.yaml
@@ -3,6 +3,7 @@ name: node1
 quorum: 3
 operation_timeout: 3sec
 check_interval: 5000ms
+cleanup_interval: 5000ms
 cluster_policy: quorum
 backend_type: pearl
 
@@ -21,4 +22,6 @@ pearl:
 
 metrics:
   name: bob
+  # this prefix resolves to `bob.X_X_X_X.node1`, where X_X_X_X is local ip address
+  prefix: '{metrics_name}.{local_address}.{node_name}'
   graphite: 127.0.0.1:2003


### PR DESCRIPTION
Now we are able to set root dir for metrics optionally + all metrics from one node are in the dir `<node_name>/<ip>/`