### PR TITLE
Holders are checked in reversed order

### DIFF
--- a/bob-backend/src/pearl/group.rs
+++ b/bob-backend/src/pearl/group.rs
@@ -193,7 +193,7 @@ impl Group {
         let holders = self.holders.read().await;
         let mut has_error = false;
         let mut results = vec![];
-        for holder in holders.iter() {
+        for holder in holders.iter().rev() {
             let get = Self::get_common(holder.clone(), key).await;
             match get {
                 Ok(data) => {


### PR DESCRIPTION
This is needed to retrieve the last record with given key (this gives a capability to perform `update` operation properly with writing new record with given key)

P. S.: On Pearl side in [PR1](https://github.com/qoollo/pearl/pull/105) and [PR2](https://github.com/qoollo/pearl/pull/102) blobs are checked in reversed order and last-added record from blob is returned (so in this PRs capability added and holders should also be checked in reversed order to support this `update` operation completely)