### PR TITLE
463 ram metrics in bytes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ Bob versions changelog
 
 
 #### Changed
+- RAM metrics (bob ram, total ram, used ram, free ram) are published in bytes now (#463)
 
 
 #### Fixed

--- a/bob/src/hw_metrics_collector.rs
+++ b/bob/src/hw_metrics_collector.rs
@@ -68,9 +68,9 @@ impl HWMetricsCollector {
         let mut dcounter = DescrCounter::new();
         let mut cpu_s_c = CPUStatCollector::new();
         let mut disk_s_c = DiskStatCollector::new(&disks);
-        let total_mem = kb_to_mb(sys.total_memory());
+        let total_mem = kb_to_b(sys.total_memory());
         gauge!(TOTAL_RAM, total_mem as f64);
-        debug!("total mem in mb: {}", total_mem);
+        debug!("total mem in bytes: {}", total_mem);
         let pid = std::process::id() as i32;
 
         loop {
@@ -95,15 +95,15 @@ impl HWMetricsCollector {
 
             if let Some(proc) = sys.process(pid) {
                 gauge!(CPU_LOAD, proc.cpu_usage() as f64);
-                let bob_ram = kb_to_mb(proc.memory());
+                let bob_ram = kb_to_b(proc.memory());
                 gauge!(BOB_RAM, bob_ram as f64);
             } else {
                 debug!("Can't get process stat descriptor");
             }
 
             let _ = Self::update_space_metrics_from_disks(&disks);
-            let used_mem = kb_to_mb(sys.used_memory());
-            debug!("used mem in mb: {}", used_mem);
+            let used_mem = kb_to_b(sys.used_memory());
+            debug!("used mem in bytes: {}", used_mem);
             gauge!(USED_RAM, used_mem as f64);
             gauge!(FREE_RAM, (total_mem - used_mem) as f64);
             gauge!(DESCRIPTORS_AMOUNT, dcounter.descr_amount() as f64);
@@ -443,8 +443,8 @@ fn bytes_to_mb(bytes: u64) -> u64 {
     bytes / 1024 / 1024
 }
 
-fn kb_to_mb(kbs: u64) -> u64 {
-    kbs / 1024
+fn kb_to_b(kbs: u64) -> u64 {
+    kbs * 1024
 }
 
 fn parse_command_output(command: &mut Command) -> Result<String, String> {


### PR DESCRIPTION
RAM metrics (bob ram, total ram, used ram, free ram) are published in bytes now
Closes #463 