### PR TITLE
563 brt argument panic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ Bob versions changelog
 
 
 #### Fixed
-
+- Fixed panic in brt because of duplicate long arg name (#563)
 
 #### Updated
 

--- a/bob-apps/bin/blob_recovery_tool/command.rs
+++ b/bob-apps/bin/blob_recovery_tool/command.rs
@@ -285,7 +285,7 @@ impl ValidateIndexCommand {
                     .takes_value(true)
                     .required(false)
                     .help(KEY_SIZE_HELP.as_str())
-                    .long("no-confirm"),
+                    .long("key-size"),
             )
     }
 


### PR DESCRIPTION
Fixed panic in brt because of duplicate long arg name
Closes #563 