### PR TITLE
Draft: Not clear indexes on remount

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ Bob versions changelog
 
 
 #### Changed
-
+- Do not clear holder timestamp indexes on remount (#692)
 
 #### Fixed
 

--- a/bob-backend/src/pearl/group.rs
+++ b/bob-backend/src/pearl/group.rs
@@ -89,7 +89,6 @@ impl Group {
 
     pub async fn remount(&self, pp: impl Hooks) -> AnyResult<()> {
         self.holders.write().await.clear();
-        self.created_holder_indexes.write().await.clear();
         self.run(pp).await
     }
 


### PR DESCRIPTION
Not clear indexes on remount. This can lead to creation of the holder with the existed timestamp, when `put` runs at the same time the remount procedure happened