### PR TITLE
Fix incorrect timestamp is used in `Group::delete()`

### DIFF
--- a/bob-backend/src/pearl/group.rs
+++ b/bob-backend/src/pearl/group.rs
@@ -341,7 +341,7 @@ impl Group {
         let mut total_deletion_count = 0;
 
         if force_delete {
-            let actual_holder = self.get_or_create_actual_holder(get_current_timestamp(), timestamp_config).await?;
+            let actual_holder = self.get_or_create_actual_holder(meta.timestamp(), timestamp_config).await?;
             reference_timestamp = actual_holder.1.start_timestamp();
             total_deletion_count += self.delete_in_actual_holder(actual_holder, key, meta).await?;
         }


### PR DESCRIPTION
Closes #741 